### PR TITLE
Rework PathStart

### DIFF
--- a/ohdlc/src/ast/ty.rs
+++ b/ohdlc/src/ast/ty.rs
@@ -3,14 +3,14 @@ use crate::{span::Spanned, symbol::Ident};
 #[derive(Debug)]
 pub struct Path(pub Vec<PathSegment>, pub PathStart);
 
-// TODO: don't we want this to be (or also be) root? maybe?
 #[derive(Debug, Clone, Copy)]
 pub enum PathStart {
-    /// Search directly in the given scope for the next path segment
+    /// Search in the root scope
     /// e.g. `::path::path`
-    Direct,
+    Root,
+    /// Search in the current scope and upwards
     /// e.g. `path::path`
-    Indirect,
+    Local,
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/ohdlc/src/ir/import_bucket.rs
+++ b/ohdlc/src/ir/import_bucket.rs
@@ -1,6 +1,6 @@
 use surotto::{simple::SimpleSurotto, simple_assoc::SimpleAssocSurotto, simple_key};
 
-use crate::{ast::PathStart, span::Span, symbol::Ident};
+use crate::{span::Span, symbol::Ident};
 
 use super::name_lookup::ScopeId;
 
@@ -31,22 +31,30 @@ impl<'ir> ImportBucket<'ir> {
 
 /// ```ohdl,ignore
 /// mod scope {
-///     // indirect
 ///     use path::path::path;
-///     // direct
-///     use ::path::path::path;
+///         ^^^^  ~~~~  ~~~~
+///          |     \direct/
+///       indirect
 /// }
 /// ```
 #[derive(Debug)]
 pub struct Import<'ir> {
     /// The scope we take the path from
     pub scope: ScopeId,
-    /// If the path starts directly or indirectly.
-    pub start: PathStart,
+    /// How the lookup of the first segment should be handled.
+    pub strategy: LookupStrategy,
     /// The path we have to take from the source
     pub path: &'ir [Ident],
     /// The whole import span
     pub span: Span,
     /// The scope the import will be added to
     pub target_scope: ScopeId,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum LookupStrategy {
+    /// Look only in the given scope.
+    Direct,
+    /// Look in the given scope and upwards.
+    Indirect,
 }

--- a/ohdlc/src/ir/stages/flatten_lookup/mod.rs
+++ b/ohdlc/src/ir/stages/flatten_lookup/mod.rs
@@ -1,9 +1,8 @@
 use std::mem::MaybeUninit;
 
 use crate::{
-    ast::PathStart,
     ir::{
-        import_bucket::{ImportBucket, ImportId},
+        import_bucket::{ImportBucket, ImportId, LookupStrategy},
         name_lookup::{
             LookupScope, PostFlattenNameLookup, PreFlattenNameLookup, Resolvable, Resolved,
         },
@@ -36,7 +35,7 @@ impl<'ir> FlattenLookupStage<'ir, '_, '_> {
                     .lookup_ignore(
                         import.scope,
                         &segment,
-                        import.start,
+                        import.strategy,
                         |r| matches!(r, Resolvable::Import(i) if *i == id),
                     )
                     .cloned()
@@ -61,7 +60,7 @@ impl<'ir> FlattenLookupStage<'ir, '_, '_> {
                                     let module = &self.registry.modules[m];
                                     let sub_path = &import.path[1..];
                                     import.scope = module.scope;
-                                    import.start = PathStart::Direct;
+                                    import.strategy = LookupStrategy::Direct;
                                     import.path = sub_path;
 
                                     continue 'single_import;
@@ -124,7 +123,7 @@ impl<'ir> FlattenLookupStage<'ir, '_, '_> {
             match self.name_lookup.lookup_ignore(
                 import.scope,
                 &import.path[0],
-                import.start,
+                import.strategy,
                 |r| matches!(r, Resolvable::Import(i) if *i == id),
             ) {
                 Some(Resolvable::Import(dep)) => self.import_bucket.dependants[*dep].push(id),

--- a/ohdlc/src/parser/ty.rs
+++ b/ohdlc/src/parser/ty.rs
@@ -13,9 +13,9 @@ impl<'s, 'a> Parser<'s, 'a> {
 
         let path_start = if self.kind()? == TokenKind::ColonColon {
             self.bump();
-            PathStart::Direct
+            PathStart::Root
         } else {
-            PathStart::Indirect
+            PathStart::Local
         };
 
         segments.push(PathSegment(self.ident()?));


### PR DESCRIPTION
Differentiate between `ast::PathStart` for syntax and `LookupStrategy` for lookup.

Now a path that starts with `::` doesn't mean that it should not look upwards the tree, but rather that it starts at the root of the tree.